### PR TITLE
Local media library implementation

### DIFF
--- a/lib/data/audio/isar/repositories/isar_music_repository.dart
+++ b/lib/data/audio/isar/repositories/isar_music_repository.dart
@@ -10,17 +10,17 @@ import 'package:dune/data/audio/isar/repositories/isar_listening_history_month_s
 import 'package:dune/data/audio/isar/repositories/isar_playlist_repository.dart';
 import 'package:dune/data/audio/isar/repositories/isar_playlists_listening_history_repository.dart';
 import 'package:dune/data/audio/isar/repositories/isar_tracks_listening_history_repository.dart';
-import 'package:dune/domain/audio/facades/music_facade.dart';
+import 'package:dune/domain/audio/repositories/base_music_repository.dart';
 import 'package:dune/domain/audio/repositories/listening_history_repository.dart';
+import 'package:dune/domain/audio/repositories/local_music_library_repository.dart';
 import 'package:dune/domain/audio/repositories/playlist_repository.dart';
-import 'package:dune/domain/audio/repositories/track_repository.dart';
 import 'package:isar/isar.dart';
 
 import 'isar_album_repository.dart';
 import 'isar_artist_repository.dart';
 import 'isar_track_repository.dart';
 
-final class IsarMusicRepository implements CacheMusicRepository {
+final class IsarMusicRepository implements BaseLocalMusicRepository {
   IsarMusicRepository({required Isar isar}) {
     final trackDataSource = IsarTrackDataSource(isar);
     final artistDataSource = IsarArtistDataSource(isar);
@@ -61,6 +61,8 @@ final class IsarMusicRepository implements CacheMusicRepository {
         isar,
       ),
     );
+    _localMusicLibrary =
+        LocalMusicLibraryRepository(_tracks, _albums, _artists, _playlists);
   }
 
   late final IsarPlaylistRepository _playlists;
@@ -68,13 +70,14 @@ final class IsarMusicRepository implements CacheMusicRepository {
   late final IsarArtistRepository _artists;
   late final IsarAlbumRepository _albums;
   late final ListeningHistoryRepository _listeningHistory;
+  late final LocalMusicLibraryRepository _localMusicLibrary;
   late final IsarModelsRelationHelper _relationHelper;
 
   @override
   SavablePlaylistRepository get playlists => _playlists;
 
   @override
-  SavableTrackRepository get tracks => _tracks;
+  IsarTrackRepository get tracks => _tracks;
 
   ListeningHistoryRepository get listeningHistory => _listeningHistory;
 
@@ -87,4 +90,7 @@ final class IsarMusicRepository implements CacheMusicRepository {
   @override
   // TODO: implement search
   get search => throw UnimplementedError();
+
+  @override
+  LocalMusicLibraryRepository get localMusicLibrary => _localMusicLibrary;
 }

--- a/lib/domain/audio/base_models/music_library.dart
+++ b/lib/domain/audio/base_models/music_library.dart
@@ -1,0 +1,19 @@
+import 'package:dune/domain/audio/base_models/base_playlist.dart';
+
+import 'base_album.dart';
+import 'base_artist.dart';
+import 'base_track.dart';
+
+class MusicLibrary {
+  final List<BaseTrack> tracks;
+  final List<BaseArtist> artists;
+  final List<BaseAlbum> albums;
+  final List<BasePlaylist> playlists;
+
+  const MusicLibrary(
+    this.tracks,
+    this.artists,
+    this.albums,
+    this.playlists,
+  );
+}

--- a/lib/domain/audio/facades/local_music_library_facade.dart
+++ b/lib/domain/audio/facades/local_music_library_facade.dart
@@ -1,0 +1,38 @@
+import 'package:dune/domain/audio/base_models/base_album.dart';
+import 'package:dune/domain/audio/base_models/base_artist.dart';
+import 'package:dune/domain/audio/base_models/base_track.dart';
+import 'package:dune/domain/audio/base_models/music_library.dart';
+import 'package:dune/domain/audio/repositories/local_music_library_repository.dart';
+import 'package:dune/support/enums/sorts.dart';
+import 'package:dune/support/utils/result/result.dart';
+
+final class LocalMusicLibraryFacade {
+  final LocalMusicLibraryRepository _repository;
+
+  LocalMusicLibraryFacade(this._repository);
+
+  FutureOrResult<MusicLibrary> loadLibrary() async {
+    return await _repository.loadLibrary();
+  }
+
+  FutureOrResult<List<BaseArtist>> getArtists({
+    SortType sortBy = SortType.alphabetically,
+    bool desc = false,
+  }) async {
+    return await _repository.getArtists(sortBy, desc);
+  }
+
+  FutureOrResult<List<BaseTrack>> getTracks({
+    SortType sortBy = SortType.alphabetically,
+    bool desc = false,
+  }) async {
+    return await _repository.getTracks(sortBy, desc);
+  }
+
+  FutureOrResult<List<BaseAlbum>> getAlbums({
+    SortType sortBy = SortType.alphabetically,
+    bool desc = false,
+  }) async {
+    return await _repository.getAlbums(sortBy, desc);
+  }
+}

--- a/lib/domain/audio/facades/music_facade.dart
+++ b/lib/domain/audio/facades/music_facade.dart
@@ -12,6 +12,7 @@ import 'package:dune/domain/audio/repositories/artist_repository.dart';
 import 'package:dune/domain/audio/repositories/base_music_repository.dart';
 import 'package:dune/domain/audio/repositories/listening_history_repository.dart';
 import 'package:dune/domain/audio/repositories/explore_music_repository.dart';
+import 'package:dune/domain/audio/repositories/local_music_library_repository.dart';
 import 'package:dune/domain/audio/repositories/playlist_repository.dart';
 import 'package:dune/domain/audio/repositories/search_repository.dart';
 import 'package:dune/domain/audio/repositories/track_repository.dart';
@@ -21,6 +22,8 @@ import 'package:dune/support/extensions/extensions.dart';
 import 'package:dune/support/logger_service.dart';
 import 'package:dune/support/utils/result/result.dart';
 import 'package:flutter/material.dart';
+
+import 'local_music_library_facade.dart';
 
 part 'playlist_facade.dart';
 
@@ -34,6 +37,7 @@ part 'user_listening_history_facade.dart';
 
 final class MusicFacade {
   MusicFacade._({
+    required LocalMusicLibraryRepository localMusicLibraryRepository,
     required CacheMusicRepository cacheMusicRepository,
     required BaseOnlineSourceMusicRepository youtubeMusicRepository,
     required ListeningHistoryRepository listeningHistoryRepository,
@@ -54,6 +58,7 @@ final class MusicFacade {
     );
     _userListeningHistory =
         UserListeningHistoryFacade(listeningHistoryRepository);
+    _localMusicLibrary = LocalMusicLibraryFacade(localMusicLibraryRepository);
   }
 
   static late MusicFacade _instance;
@@ -79,7 +84,13 @@ final class MusicFacade {
   static UserListeningHistoryFacade get userListeningHistory =>
       _instance._userListeningHistory;
 
+  late final LocalMusicLibraryFacade _localMusicLibrary;
+
+  static LocalMusicLibraryFacade get localMusicLibrary =>
+      _instance._localMusicLibrary;
+
   static void setInstance({
+    required LocalMusicLibraryRepository localMusicLibraryRepository,
     required CacheMusicRepository cacheMusicRepository,
     required BaseOnlineSourceMusicRepository youtubeMusicRepository,
     required ListeningHistoryRepository listeningHistoryRepository,
@@ -88,6 +99,7 @@ final class MusicFacade {
       cacheMusicRepository: cacheMusicRepository,
       youtubeMusicRepository: youtubeMusicRepository,
       listeningHistoryRepository: listeningHistoryRepository,
+      localMusicLibraryRepository: localMusicLibraryRepository,
     );
   }
 }

--- a/lib/domain/audio/facades/music_facade.dart
+++ b/lib/domain/audio/facades/music_facade.dart
@@ -7,12 +7,9 @@ import 'package:dune/domain/audio/base_models/base_listening_history_month_summa
 import 'package:dune/domain/audio/base_models/base_track.dart';
 import 'package:dune/domain/audio/base_models/base_track_listening_history.dart';
 import 'package:dune/domain/audio/base_models/listening_history_collection.dart';
-import 'package:dune/domain/audio/repositories/album_repository.dart';
-import 'package:dune/domain/audio/repositories/artist_repository.dart';
 import 'package:dune/domain/audio/repositories/base_music_repository.dart';
 import 'package:dune/domain/audio/repositories/listening_history_repository.dart';
 import 'package:dune/domain/audio/repositories/explore_music_repository.dart';
-import 'package:dune/domain/audio/repositories/local_music_library_repository.dart';
 import 'package:dune/domain/audio/repositories/playlist_repository.dart';
 import 'package:dune/domain/audio/repositories/search_repository.dart';
 import 'package:dune/domain/audio/repositories/track_repository.dart';
@@ -37,18 +34,17 @@ part 'user_listening_history_facade.dart';
 
 final class MusicFacade {
   MusicFacade._({
-    required LocalMusicLibraryRepository localMusicLibraryRepository,
-    required CacheMusicRepository cacheMusicRepository,
+    required BaseLocalMusicRepository localMusicRepository,
     required BaseOnlineSourceMusicRepository youtubeMusicRepository,
     required ListeningHistoryRepository listeningHistoryRepository,
   }) {
     _playlists = PlaylistFacade(
       youtubePlaylistRepository: youtubeMusicRepository.playlists,
-      localPlaylistRepository: cacheMusicRepository.playlists,
+      localPlaylistRepository: localMusicRepository.playlists,
     );
     _tracks = TrackFacade(
       youtubeTrackRepository: youtubeMusicRepository.tracks,
-      localTrackRepository: cacheMusicRepository.tracks,
+      localTrackRepository: localMusicRepository.tracks,
     );
     _search = SearchFacade(
       youtubeSearchRepository: youtubeMusicRepository.search,
@@ -58,7 +54,8 @@ final class MusicFacade {
     );
     _userListeningHistory =
         UserListeningHistoryFacade(listeningHistoryRepository);
-    _localMusicLibrary = LocalMusicLibraryFacade(localMusicLibraryRepository);
+    _localMusicLibrary =
+        LocalMusicLibraryFacade(localMusicRepository.localMusicLibrary);
   }
 
   static late MusicFacade _instance;
@@ -90,23 +87,14 @@ final class MusicFacade {
       _instance._localMusicLibrary;
 
   static void setInstance({
-    required LocalMusicLibraryRepository localMusicLibraryRepository,
-    required CacheMusicRepository cacheMusicRepository,
+    required BaseLocalMusicRepository localMusicRepository,
     required BaseOnlineSourceMusicRepository youtubeMusicRepository,
     required ListeningHistoryRepository listeningHistoryRepository,
   }) {
     _instance = MusicFacade._(
-      cacheMusicRepository: cacheMusicRepository,
+      localMusicRepository: localMusicRepository,
       youtubeMusicRepository: youtubeMusicRepository,
       listeningHistoryRepository: listeningHistoryRepository,
-      localMusicLibraryRepository: localMusicLibraryRepository,
     );
   }
 }
-
-typedef CacheMusicRepository = BaseMusicRepository<
-    SavablePlaylistRepository,
-    SavableTrackRepository,
-    ArtistRepository,
-    AlbumRepository,
-    SearchRepository>;

--- a/lib/domain/audio/repositories/base_music_repository.dart
+++ b/lib/domain/audio/repositories/base_music_repository.dart
@@ -1,3 +1,5 @@
+import 'package:dune/domain/audio/repositories/local_music_library_repository.dart';
+
 import 'album_repository.dart';
 import 'artist_repository.dart';
 import 'explore_music_repository.dart';
@@ -33,4 +35,15 @@ abstract interface class BaseOnlineSourceMusicRepository<
         ExploreMusic extends ExploreMusicRepository>
     implements BaseMusicRepository<Playlists, Tracks, Artists, Albums, Search> {
   ExploreMusic get exploreMusic;
+}
+
+abstract interface class BaseLocalMusicRepository<
+        Playlists extends SavablePlaylistRepository,
+        Tracks extends SavableTrackRepository,
+        Artists extends SavableArtistRepository,
+        Albums extends SavableAlbumRepository,
+        Search extends SearchRepository,
+        LocalMusicLibrary extends LocalMusicLibraryRepository>
+    implements BaseMusicRepository<Playlists, Tracks, Artists, Albums, Search> {
+  LocalMusicLibrary get localMusicLibrary;
 }

--- a/lib/domain/audio/repositories/local_music_library_repository.dart
+++ b/lib/domain/audio/repositories/local_music_library_repository.dart
@@ -1,0 +1,44 @@
+import 'package:dune/domain/audio/base_models/base_album.dart';
+import 'package:dune/domain/audio/base_models/base_artist.dart';
+import 'package:dune/domain/audio/base_models/base_track.dart';
+import 'package:dune/domain/audio/base_models/music_library.dart';
+import 'package:dune/domain/audio/repositories/album_repository.dart';
+import 'package:dune/domain/audio/repositories/artist_repository.dart';
+import 'package:dune/domain/audio/repositories/track_repository.dart';
+import 'package:dune/support/enums/sorts.dart';
+import 'package:dune/support/utils/result/result.dart';
+
+import 'playlist_repository.dart';
+
+class LocalMusicLibraryRepository {
+  final SavableTrackRepository _trackRepository;
+  final SavableAlbumRepository _albumRepository;
+  final SavableArtistRepository _artistRepository;
+  final SavablePlaylistRepository _playlistRepository;
+
+  const LocalMusicLibraryRepository(
+    this._trackRepository,
+    this._albumRepository,
+    this._artistRepository,
+    this._playlistRepository,
+  );
+
+  FutureOrResult<MusicLibrary> loadLibrary() async {
+    throw UnimplementedError();
+  }
+
+  FutureOrResult<List<BaseArtist>> getArtists(
+    SortType sortBy,
+    bool desc,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  FutureOrResult<List<BaseTrack>> getTracks(SortType sortBy, bool desc) async {
+    throw UnimplementedError();
+  }
+
+  FutureOrResult<List<BaseAlbum>> getAlbums(SortType sortBy, bool desc) async {
+    throw UnimplementedError();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ Future<void> _registerDependencies() async {
   // IsarTrackListeningHistorySeeder(isarMusicRepository, isar).seedCount();
 
   MusicFacade.setInstance(
-    cacheMusicRepository: isarMusicRepository,
+    localMusicRepository: isarMusicRepository,
     listeningHistoryRepository: isarMusicRepository.listeningHistory,
     youtubeMusicRepository: YoutubeMusicRepository(),
   );

--- a/lib/support/enums/sorts.dart
+++ b/lib/support/enums/sorts.dart
@@ -1,0 +1,5 @@
+enum SortType {
+  alphabetically,
+  releaseDate,
+  dateAdded,
+}


### PR DESCRIPTION
#2 
Created the following required classes:

- [x] LocalMusicLibraryFacade: contains only a public interface which can be used by other components. Has a `LocalMusicRepository`
- [x] LocalMusicLibraryRepository: contains the logic for:

    - loading previously-stored music library.
    - add a list of tracks to the stored music library.
    - has a `SavableTrackRepository` instance which is delegated for saving a list of `BaseTrack` into the DB.